### PR TITLE
Scaling of buttons

### DIFF
--- a/resources/ui/hud_theme.tres
+++ b/resources/ui/hud_theme.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Theme" script_class="ScaleAwareTheme" load_steps=2 format=3 uid="uid://daewuul3ri2pl"]
+
+[ext_resource type="Script" uid="uid://cpnn4ftit3uje" path="res://scripts/scale_aware_theme.gd" id="1_28gy7"]
+
+[resource]
+default_font_size = 24
+script = ExtResource("1_28gy7")
+base_font_size = 24

--- a/scenes/ui_components/hud.tscn
+++ b/scenes/ui_components/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://bpc6gps3lk4ac"]
+[gd_scene load_steps=35 format=3 uid="uid://bpc6gps3lk4ac"]
 
 [ext_resource type="Script" uid="uid://cp4f0pub28xa" path="res://scripts/ui_components/hud.gd" id="1_cjm6u"]
 [ext_resource type="Script" uid="uid://bxf2bs8khmutf" path="res://scripts/turn_counter.gd" id="1_xgrr2"]
@@ -12,6 +12,7 @@
 [ext_resource type="LabelSettings" uid="uid://dte7ki6on48e4" path="res://resources/ui/label_settings_regular.tres" id="7_a6ec8"]
 [ext_resource type="Script" uid="uid://4lk24jcuaq6g" path="res://scripts/ui_components/building/active_button_tracker.gd" id="9_do4pv"]
 [ext_resource type="Script" uid="uid://b2eoxpgf2ve3o" path="res://scripts/ui_components/building/building_button.gd" id="9_jswg8"]
+[ext_resource type="Theme" uid="uid://daewuul3ri2pl" path="res://resources/ui/hud_theme.tres" id="11_6pkrv"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2itkv"]
 content_margin_left = 12.0
@@ -432,8 +433,8 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 40)
 layout_mode = 2
 focus_mode = 0
+theme = ExtResource("11_6pkrv")
 theme_override_colors/font_color = Color(0.05882353, 0.40392157, 0.41960785, 1)
-theme_override_font_sizes/font_size = 24
 theme_override_styles/normal = SubResource("StyleBoxEmpty_ij283")
 text = "Next Turn"
 script = ExtResource("2_ntdy2")

--- a/scripts/scale_aware_theme.gd
+++ b/scripts/scale_aware_theme.gd
@@ -1,0 +1,16 @@
+@tool
+class_name ScaleAwareTheme
+extends Theme
+
+@export var base_font_size:int = 18:
+	set(v):
+		base_font_size = v
+		_update_scale(UiScaleManager.scale)
+
+func _init() -> void:
+	UiScaleManager.scale_changed.connect(_update_scale)
+	_update_scale(UiScaleManager.scale)
+
+
+func _update_scale(new_scale:float) -> void:
+	default_font_size = base_font_size * new_scale

--- a/scripts/scale_aware_theme.gd.uid
+++ b/scripts/scale_aware_theme.gd.uid
@@ -1,0 +1,1 @@
+uid://cpnn4ftit3uje


### PR DESCRIPTION
Uses a new type (ScaleAwareTheme) to change the theme's font size. Currently the colors aren't configured since all of the HUD elements are setting their own theme overrides. Cleaning that up would be good to do with a later PR such as in conjunction with #95.