### PR TITLE
Make max_level always the same as upgrade cost length

### DIFF
--- a/scripts/buildings/building.gd
+++ b/scripts/buildings/building.gd
@@ -4,7 +4,6 @@ extends Node2D
 
 
 @export var building_spec: BuildingSpec
-@export var max_level: int
 # NOTE: scale all inherited building sprites here across the entire game
 @export var building_scale := Vector2(4, 4)
 
@@ -25,6 +24,10 @@ var is_cursor: bool = false
 var building_id: int = -1
 var is_powered: bool
 var current_level: int = 1
+
+var max_level: int:
+	get:
+		return building_spec.cost_levels.size()
 
 
 func _ready() -> void:


### PR DESCRIPTION
Making the max level implicitly set by how many upgrade costs are defined is less error prone.